### PR TITLE
Exceptional improvement: Improve how loggers will handle K8SException

### DIFF
--- a/client/src/main/scala/skuber/api/Configuration.scala
+++ b/client/src/main/scala/skuber/api/Configuration.scala
@@ -15,65 +15,65 @@ import java.util.Base64
  */
 case class Configuration(
       clusters: Map[String, Cluster] = Map(),
-      contexts: Map[String, Context] = Map(),  
+      contexts: Map[String, Context] = Map(),
       currentContext: Context = Context(),
       users: Map[String, AuthInfo] = Map()) {
-      
+
       def withCluster(name:String, cluster: Cluster) = this.copy(clusters = this.clusters + (name -> cluster))
       def withContext(name: String, context: Context) = this.copy(contexts = this.contexts + (name -> context))
-      def useContext(context: Context) = this.copy(currentContext=context) 
+      def useContext(context: Context) = this.copy(currentContext=context)
 }
 
 object Configuration {
 
     // default config is suitable for use with kubectl proxy running on localhost:8001
     lazy val default = Configuration(
-        clusters = Map("default" -> Cluster()), 
+        clusters = Map("default" -> Cluster()),
         contexts= Map("default" -> Context()),
         currentContext = Context())
-        
+
     /**
-     * Parse a kubeconfig file to get a K8S Configuration object for the API. 
+     * Parse a kubeconfig file to get a K8S Configuration object for the API.
      *
      * See https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/kubeconfig-file.md
-     * for format of the kubeconfig file.   
+     * for format of the kubeconfig file.
      * Enables sharing of config with kubectl when skuber client is not simply directed via a kubectl proxy
      * However note that the merging functionality described at the link above is not implemented
-     * in the Skuber library.    
+     * in the Skuber library.
     **/
     import java.nio.file.{Path,Paths,Files}
     def parseKubeconfigFile(path: Path = Paths.get(System.getProperty("user.home"),".kube", "config")) : Try[Configuration] = {
        parseKubeconfigStream(Files.newInputStream(path))
     }
-    
+
     def parseKubeconfigStream(is: java.io.InputStream) : Try[Configuration]= {
-      
+
       type YamlMap= java.util.Map[String, Object]
       type TopLevelYamlList = java.util.List[YamlMap]
-      
+
       Try {
-        val yaml = new Yaml()        
+        val yaml = new Yaml()
         val mainConfig = yaml.load(is).asInstanceOf[YamlMap]
-        
-        def name(parent: YamlMap) = 
-          parent.get("name").asInstanceOf[String]  
-        
-        def child(parent: YamlMap, key: String) = 
+
+        def name(parent: YamlMap) =
+          parent.get("name").asInstanceOf[String]
+
+        def child(parent: YamlMap, key: String) =
           parent.get(key).asInstanceOf[YamlMap]
-        
-        def topLevelList(key: String) = 
+
+        def topLevelList(key: String) =
           mainConfig.get(key).asInstanceOf[TopLevelYamlList]
-        
-        def valueAt[T](parent: YamlMap, key: String, fallback: Option[T] = None) : T = 
+
+        def valueAt[T](parent: YamlMap, key: String, fallback: Option[T] = None) : T =
           parent.asScala.get(key).orElse(fallback).get.asInstanceOf[T]
-        
-        def optionalValueAt[T](parent: YamlMap, key: String) : Option[T] = 
+
+        def optionalValueAt[T](parent: YamlMap, key: String) : Option[T] =
           parent.asScala.get(key).map(_.asInstanceOf[T])
-            
+
         def pathOrDataValueAt[T](parent: YamlMap, pathKey: String, dataKey: String) : Option[PathOrData] = {
           val path = optionalValueAt[String](parent, pathKey)
           val data = optionalValueAt[String](parent, dataKey)
-          // Return some Right if data value is set, otherwise some Left if path value is set 
+          // Return some Right if data value is set, otherwise some Left if path value is set
           // if neither is set return None
           // Note - implication is that a data setting overrides a path setting
           (path, data) match {
@@ -82,43 +82,43 @@ object Configuration {
             case (None, None) => None
           }
         }
-        
+
         def topLevelYamlToK8SConfigMap[K8SConfigKind](kind: String, toK8SConfig: YamlMap=> K8SConfigKind) =
           topLevelList(kind + "s").asScala.map(item => name(item) -> toK8SConfig(child(item, kind))).toMap
-          
+
         def toK8SCluster(clusterConfig: YamlMap) =
           Cluster(
             apiVersion=valueAt(clusterConfig, "api-version", Some("v1")),
             server=valueAt(clusterConfig,"server",Some("http://localhost:8001")),
             insecureSkipTLSVerify=valueAt(clusterConfig,"insecure-skip-tls-verify",Some(false)),
             certificateAuthority=pathOrDataValueAt(clusterConfig, "certificate-authority","certificate-authority-data"))
-            
-                   
+
+
         val k8sClusterMap = topLevelYamlToK8SConfigMap("cluster", toK8SCluster _)
-              
-        def toK8SAuthInfo(userConfig:YamlMap) =      
+
+        def toK8SAuthInfo(userConfig:YamlMap) =
           AuthInfo(
             clientCertificate=pathOrDataValueAt(userConfig, "client-certificate","client-certificate-data"),
             clientKey=pathOrDataValueAt(userConfig, "client-key","client-key-data"),
             token=optionalValueAt(userConfig, "token"),
             userName=optionalValueAt(userConfig, "username"),
             password=optionalValueAt(userConfig, "password"))
-                      
-        val k8sAuthInfoMap = topLevelYamlToK8SConfigMap("user", toK8SAuthInfo _)                            
-      
+
+        val k8sAuthInfoMap = topLevelYamlToK8SConfigMap("user", toK8SAuthInfo _)
+
         def toK8SContext(contextConfig: YamlMap) = {
           val cluster=contextConfig.asScala.get("cluster").flatMap(clusterName => k8sClusterMap.get(clusterName.asInstanceOf[String])).get
           val authInfo =contextConfig.asScala.get("user").flatMap(userKey => k8sAuthInfoMap.get(userKey.asInstanceOf[String])).get
           val namespace=contextConfig.asScala.get("namespace").fold(Namespace.default) { name=>Namespace.forName(name.asInstanceOf[String]) }
-          Context(cluster,authInfo,namespace)    
-        }       
-        
+          Context(cluster,authInfo,namespace)
+        }
+
         val k8sContextMap = topLevelYamlToK8SConfigMap("context", toK8SContext _)
-        
+
         val currentContextStr: Option[String] = optionalValueAt(mainConfig, "current-context")
         val currentContext = currentContextStr.flatMap(k8sContextMap.get(_)).getOrElse(Context())
-        
+
         Configuration(k8sClusterMap, k8sContextMap, currentContext, k8sAuthInfoMap)
       }
-    }    
+    }
 }

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -21,72 +21,72 @@ import org.slf4j.LoggerFactory
 package object client {
 
   val log = LoggerFactory.getLogger("skuber.api")
-  
+
   // Certificates and keys can be specified in configuration either as paths to files or embedded PEM data
   type PathOrData = Either[String,Array[Byte]]
-  
+
    // K8S client API classes
    val defaultApiServerURL = "http://localhost:8080"
    case class Cluster(
-     apiVersion: String = "v1",  
+     apiVersion: String = "v1",
      server: String = defaultApiServerURL,
      insecureSkipTLSVerify: Boolean = false,
      certificateAuthority: Option[PathOrData] = None
    )
-   
+
    case class Context(
-     cluster: Cluster = Cluster(), 
+     cluster: Cluster = Cluster(),
      authInfo: AuthInfo = AuthInfo(),
-     namespace: Namespace = Namespace.default 
+     namespace: Namespace = Namespace.default
    )
-     
+
    case class AuthInfo(
      clientCertificate: Option[PathOrData] = None,
      clientKey: Option[PathOrData] = None,
      token: Option[String] = None,
      userName: Option[String] = None,
      password: Option[String] = None
-   ) 
-   
+   )
+
    // for use with the Watch command
    case class WatchEvent[T <: ObjectResource](_type: EventType.Value, _object: T)
    object EventType extends Enumeration {
       type EventType = Value
       val ADDED,MODIFIED,DELETED,ERROR = Value
    }
-     
-   
-   class RequestContext(k8sContext: Context)(implicit executorContext: ExecutionContext) { 
+
+
+   class RequestContext(k8sContext: Context)(implicit executorContext: ExecutionContext) {
       val sslContext = TLS.establishSSLContext(k8sContext)
       val requestAuth = HTTPRequestAuth.establishRequestAuth(k8sContext)
 //      val wsConfig = new NingAsyncHttpClientConfigBuilder(WSClientConfig()).build
 //      val httpClient = new NingWSClient(wsConfig)
      val httpClientConfigBuilder = new AsyncHttpClientConfig.Builder
      sslContext foreach { ctx =>
-        httpClientConfigBuilder.setSSLContext(ctx) 
+        httpClientConfigBuilder.setSSLContext(ctx)
         // following is needed to prevent SSLv2Hello being used in SSL handshake - which Kubernetes doesn't like
-        httpClientConfigBuilder.setEnabledProtocols(Array("TLSv1.2","TLSv1")) 
+        httpClientConfigBuilder.setEnabledProtocols(Array("TLSv1.2","TLSv1"))
      }
      val httpClientConfig = httpClientConfigBuilder.build
      val httpClient = new NingWSClient(httpClientConfig)
-     
+
      val namespaceName = k8sContext.namespace.name match {
         case "" => "default"
         case name => name
      }
-      
+
      val nsPathComponent =  Some("namespaces/" + namespaceName)
-      
+
      def executionContext = executorContext
-      
+
      def buildRequest[T <: TypeMeta](
        nameComponent: Option[String],
        watch: Boolean = false,
        forExtensionsAPI: Option[Boolean] = None
        )(implicit kind: Kind[T]) : WSRequest =
-     {  
+     {
        val kindComponent = kind.urlPathComponent
-       val apiVersion = kind.apiVersion 
+       val apiVersion = kind.apiVersion
        val usesExtensionsAPI = forExtensionsAPI.getOrElse(kind.isExtensionsKind)
        val apiPrefix = if (usesExtensionsAPI) "apis" else "api"
 
@@ -102,33 +102,33 @@ package object client {
            }
          })
        }
-        
+
        val watchPathComponent=if (watch) Some("watch") else None
 
        val k8sUrlStr = mkUrlString(
-         Some(k8sContext.cluster.server), 
-         Some(apiPrefix), 
-         Some(apiVersion), 
+         Some(k8sContext.cluster.server),
+         Some(apiPrefix),
+         Some(apiVersion),
          watchPathComponent,
          if (kind.isNamespaced) nsPathComponent else None,
          Some(kindComponent),
-         nameComponent)     
-         
+         nameComponent)
+
        val req = httpClient.url(k8sUrlStr)
         HTTPRequestAuth.addAuth(req, requestAuth)
       }
-      
+
       def logRequest(request: WSRequest, objName: String, json: Option[JsValue] = None) : Unit =
         if (log.isInfoEnabled())
         {
            val info = "method=" + request.method + ",url=" + request.url
            val debugInfo =
              if (log.isDebugEnabled())
-                             Some(",namespace=" + namespaceName + ",url=" + request.url + 
+                             Some(",namespace=" + namespaceName + ",url=" + request.url +
                                        request.queryString.headOption.map {
-                                         case (s, seq) => ",query='" + s + "=" + seq.headOption.getOrElse("") + "'"                                    
+                                         case (s, seq) => ",query='" + s + "=" + seq.headOption.getOrElse("") + "'"
                                        }.getOrElse("")
-                                    + json.fold("")(js => ",body=" + js.toString())) 
+                                    + json.fold("")(js => ",body=" + js.toString()))
              else
                None
            log.info("[Skuber Request: " + info + debugInfo.getOrElse("") + "]")
@@ -149,18 +149,18 @@ package object client {
                       withHeaders("Content-Type" -> "application/json").
                       withMethod(method).
                       withBody(js)
-        logRequest(wsReq, obj.name, Some(js))              
-       
+        logRequest(wsReq, obj.name, Some(js))
+
         val wsResponse = wsReq.execute()
         wsResponse map toKubernetesResponse[O]
       }
-      
+
       def create[O <: ObjectResource](obj: O)(implicit fmt: Format[O], kind: ObjKind[O]) = modify("POST")(obj)
       def update[O <: ObjectResource](obj: O)(implicit fmt: Format[O],  kind: ObjKind[O]) = modify("PUT")(obj)
       def partiallyUpdate[O <: ObjectResource](obj: O)(implicit fmt: Format[O],  kind: ObjKind[O]) = modify("PATCH")(obj)
-   
-      
-     def list[L <: KList[_]]()(implicit fmt: Format[L], kind: ListKind[L]) : Future[L] = 
+
+
+     def list[L <: KList[_]]()(implicit fmt: Format[L], kind: ListKind[L]) : Future[L] =
      {
        val wsReq = buildRequest(None)(kind)
        logRequest(wsReq, kind.urlPathComponent, None)
@@ -189,58 +189,58 @@ package object client {
                       withHeaders("Content-Type" -> "application/json").
                       withBody(js).withMethod("DELETE")
        logRequest(wsReq, name, None)
-       val wsResponse = wsReq.delete             
-       wsResponse map checkResponseStatus 
+       val wsResponse = wsReq.delete
+       wsResponse map checkResponseStatus
      }
-     
-     
+
+
      // The Watch methods place a Watch on the specified resource on the Kubernetes cluster.
-     // The methods return Play Framework enumerators that will reactively emit a stream of updated 
+     // The methods return Play Framework enumerators that will reactively emit a stream of updated
      // values of the watched resources.
-    
+
      import play.api.libs.iteratee.Enumerator
-     
-     def watch[O <: ObjectResource](obj: O)(implicit objfmt: Format[O],  kind: ObjKind[O]) : Watch[WatchEvent[O]] = Watch.events(this, obj)       
+
+     def watch[O <: ObjectResource](obj: O)(implicit objfmt: Format[O],  kind: ObjKind[O]) : Watch[WatchEvent[O]] = Watch.events(this, obj)
      def watch[O <: ObjectResource](name: String,
                                     sinceResourceVersion: Option[String] = None)
-                                    (implicit objfmt: Format[O], kind: ObjKind[O]) : Watch[WatchEvent[O]] =  Watch.events(this, name, sinceResourceVersion)                                           
- 
+                                    (implicit objfmt: Format[O], kind: ObjKind[O]) : Watch[WatchEvent[O]] =  Watch.events(this, name, sinceResourceVersion)
+
      // watch events on all objects of specified kind in current namespace
-     def watchAll[O <: ObjectResource](sinceResourceVersion: Option[String] = None)(implicit fmt: Format[O], kind: ObjKind[O])  = 
-             Watch.eventsOnKind[O](this,sinceResourceVersion)      
-       
-             
+     def watchAll[O <: ObjectResource](sinceResourceVersion: Option[String] = None)(implicit fmt: Format[O], kind: ObjKind[O])  =
+             Watch.eventsOnKind[O](this,sinceResourceVersion)
+
+
      // get API versions supported by the cluster - against current v1.x versions of Kubernetes this returns just "v1"
      def getServerAPIVersions(): Future[List[String]] = {
        val url = k8sContext.cluster.server + "/api"
        val noAuthReq = httpClient.url(url)
-       val wsReq = HTTPRequestAuth.addAuth(noAuthReq, requestAuth)     
+       val wsReq = HTTPRequestAuth.addAuth(noAuthReq, requestAuth)
        log.info("[Skuber Request: method=GET, resource=api/, description=APIVersions]")
-              
+
        val wsResponse = wsReq.get
-       wsResponse map toKubernetesResponse[APIVersions] map { _.versions } 
+       wsResponse map toKubernetesResponse[APIVersions] map { _.versions }
      }
-     
+
      def close = {
         httpClient.close
      }
    }
-   
+
    // basic resource kinds supported by the K8S API server
-   abstract class Kind[T <: TypeMeta](implicit fmt: Format[T]) { 
-     def urlPathComponent: String 
+   abstract class Kind[T <: TypeMeta](implicit fmt: Format[T]) {
+     def urlPathComponent: String
      def isExtensionsKind: Boolean = false
      def isNamespaced: Boolean = true
      def apiVersion: String =
-       if (isExtensionsKind) 
-         skuber.ext.extensionsAPIVersion 
+       if (isExtensionsKind)
+         skuber.ext.extensionsAPIVersion
        else
          "v1"
    }
 
    case class ObjKind[O <: ObjectResource](
-       val urlPathComponent: String, 
-       kind: String)(implicit fmt: Format[O]) 
+       val urlPathComponent: String,
+       kind: String)(implicit fmt: Format[O])
        extends Kind[O]
 
    implicit val podKind = ObjKind[Pod]("pods", "Pod")
@@ -258,7 +258,7 @@ package object client {
    implicit val resourceQuotaKind = ObjKind[Resource.Quota]("resourcequotas", "ResourceQuota")
    implicit val configMapKind = ObjKind[ConfigMap]("configmaps", "ConfigMap")
 
-   case class ListKind[L <: TypeMeta](val urlPathComponent: String, val apiPrefix: String = "api")(implicit fmt: Format[L]) 
+   case class ListKind[L <: TypeMeta](val urlPathComponent: String, val apiPrefix: String = "api")(implicit fmt: Format[L])
      extends Kind[L]
    implicit val podListKind = ListKind[PodList]("pods")
    implicit val nodeListKind = new ListKind[NodeList]("nodes") { override def isNamespaced = false }
@@ -276,9 +276,9 @@ package object client {
 
   // Status will usually be returned by Kubernetes when an error occurs with a request
   case class Status(
-    apiVersion: String = "v1",   
+    apiVersion: String = "v1",
     kind: String = "Status",
-    metadata: ListMeta = ListMeta(),   
+    metadata: ListMeta = ListMeta(),
     status: Option[String] =None,
     message: Option[String]=None,
     reason: Option[String]=None,
@@ -308,7 +308,7 @@ package object client {
     checkResponseStatus(response)
     response.json.validate[T].asOpt
   }
-  
+
   // check for non-OK status, throwing a K8SException if appropriate
   def checkResponseStatus(response: WSResponse) : Unit ={
     response.status match {
@@ -320,7 +320,7 @@ package object client {
           case JsSuccess(status, path) =>
             if (log.isWarnEnabled)
               log.warn("[Skuber Response: non-ok status returned = " + status)
-	    throw new K8SException(status)
+              throw new K8SException(status)
           case JsError(e) => // unexpected response, so generate a Status
             val status=Status(message=Some("Unexpected response body for non-OK status "),
                               reason=Some(response.statusText),
@@ -328,24 +328,24 @@ package object client {
                               code=Some(response.status))
             if (log.isErrorEnabled)
               log.error("[Skuber Response: status code = " + code + ", error parsing body = " + e)
-            throw new K8SException(status)    
+            throw new K8SException(status)
         }
       }
     }
-  }  
-  
+  }
+
   // Delete options are passed with a Delete request
   case class DeleteOptions(
     apiVersion: String = "v1",
     kind: String = "DeleteOptions",
     gracePeriodSeconds: Int = 0)
-    
+
   def buildBaseConfigForURL(url: Option[String]) = {
     val cluster = Cluster(server=url.getOrElse(defaultApiServerURL))
     val context = Context(cluster=cluster)
     Configuration().useContext(context)
   }
-  
+
   def init(implicit executionContext : ExecutionContext): RequestContext = {
     // Initialising without explicit Configuration.
     // The K8S Configuration applied will be determined by the the environment variable 'SKUBERCONFIG'.
@@ -354,11 +354,11 @@ package object client {
     // -
     // - "file" : Configure from kubeconfig file at default location (~/.kube/config)
     // - "file://<path>: Configure from the kubeconfig file at the specified location
-    // Further the base server URL if kubectl proxy is determined by SKUBERPROXY - or just 
+    // Further the base server URL if kubectl proxy is determined by SKUBERPROXY - or just
     // 'http://localhost:8080' if not set.
-    // Note that the configurations that use the kubectl proxy assumes default namespace context, and delegates auth etc. 
+    // Note that the configurations that use the kubectl proxy assumes default namespace context, and delegates auth etc.
     // to the proxy.
-    // If configured to use  a kubeconfig file note that any certificate/key data in the file will be ignored - any 
+    // If configured to use  a kubeconfig file note that any certificate/key data in the file will be ignored - any
     // required key/cert data for TLS connections must be installed in the applicable Java keystore/truststore.
     //
     val skuberConfigEnv = sys.env.get("SKUBER_CONFIG")
@@ -373,6 +373,6 @@ package object client {
     }
     init(config)
   }
-  
+
   def init(config: Configuration)(implicit executionContext : ExecutionContext) = new RequestContext(config.currentContext)
 }

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -284,10 +284,10 @@ package object client {
     reason: Option[String]=None,
     details: Option[Any] = None,
     code: Option[Int] = None  // HTTP status code
-  ) 
-  
-  class K8SException(val status: Status) extends RuntimeException (status.message.getOrElse(status.toString)) // we throw this when we receive a non-OK response
-   
+  )
+
+  class K8SException(val status: Status) extends RuntimeException (status.toString) // we throw this when we receive a non-OK response
+
   def toKubernetesResponse[T](response: WSResponse)(implicit reader: Reads[T]) : T = {
     checkResponseStatus(response)
     val result = response.json.validate[T]


### PR DESCRIPTION
https://dominodatalab.atlassian.net/browse/DOM-2067

When loggers see an exception as an argument, they're generally just going to print the message field. The old implementation of how Skuber surfaced that message field could create situations where you only got "null" on the exception trace - which is very not helpful for debugging Kubernetes validation errors.

This will now always do a simple `toString` on status, which is much more useful behavior in terms of surfacing detailed information about error conditions.
